### PR TITLE
allow classpath to be overridden by property

### DIFF
--- a/src/main/java/org/datanucleus/maven/AbstractDataNucleusMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractDataNucleusMojo.java
@@ -57,7 +57,7 @@ public abstract class AbstractDataNucleusMojo extends AbstractMojo
     protected String metadataExcludes;
 
     /**
-     * @parameter expression="${project.compileClasspathElements}"
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
      * @required
      */
     private List classpathElements;


### PR DESCRIPTION
@andyjefferson this allows the overriding of the classpath for the enhancer.

 I want to enhance test classes, and can get halfway there by using the `metadataDirectory` property override to specify the test-classes directory. This change lets me also override the classpath (to `${project.testClasspathElements}`) which allows the enhancer to work with test dependencies (currently the enhancer classpath is hardwired to `${project.compileClasspathElements}` which won't have test-scoped dependencies).
