### PR TITLE
Use java executable from the same JVM by using the java.home path.

### DIFF
--- a/src/main/java/org/datanucleus/maven/AbstractEnhancerMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractEnhancerMojo.java
@@ -135,7 +135,7 @@ public abstract class AbstractEnhancerMojo extends AbstractDataNucleusMojo
         {
             // Create a CommandLine for execution
             Commandline cl = new Commandline();
-            cl.setExecutable("java");
+            cl.setExecutable(new File(new File(System.getProperty("java.home"), "bin"), "java").getAbsolutePath());
 
             // uncomment the following if you want to debug the enhancer
             // cl.addArguments(new String[]{"-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000"});

--- a/src/main/java/org/datanucleus/maven/AbstractSchemaToolMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractSchemaToolMojo.java
@@ -190,7 +190,7 @@ public abstract class AbstractSchemaToolMojo extends AbstractDataNucleusMojo
         {
             // Create a CommandLine for execution
             Commandline cl = new Commandline();
-            cl.setExecutable("java");
+            cl.setExecutable(new File(new File(System.getProperty("java.home"), "bin"), "java").getAbsolutePath());
 
             cl.createArg().setValue("-cp");
             cl.createArg().setValue(cpBuffer.toString());


### PR DESCRIPTION
My default java command is from an older platform, which resulted in a failure with "Unsupported major.minor version 51.0". This patch fixes the problem. I checked how other plugins, namely jaxws-maven-plugin, handle it.
