### PR TITLE
fixes #5 - adds 'test-enhance' and 'test-enhance-check' goals.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,7 +5,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.iml
 /bin
 /target

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation=0

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.datanucleus</groupId>
         <artifactId>datanucleus-maven-parent</artifactId>
-        <version>4.0.5</version>
+        <version>5.0.0</version>
     </parent>
 
     <artifactId>datanucleus-maven-plugin</artifactId>
-    <version>4.0.6-SNAPSHOT</version>
+    <version>5.0.0-release-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>DataNucleus Maven Plugin</name>
@@ -46,14 +46,14 @@
         <dependency>
             <groupId>org.datanucleus</groupId>
             <artifactId>datanucleus-core</artifactId>
-            <version>(3.9, )</version>
+            <version>[5.0.0-m1, )</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
-            <groupId>javax.jdo</groupId>
-            <artifactId>jdo-api</artifactId>
-            <version>[3.0.1, )</version>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>javax.jdo</artifactId>
+            <version>[3.2.0-m5, )</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-maven-plugin</artifactId>
-    <version>5.0.1-release-SNAPSHOT</version>
+    <version>5.0.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>DataNucleus Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-maven-plugin</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>DataNucleus Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-maven-plugin</artifactId>
-    <version>5.0.1</version>
+    <version>5.0.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>DataNucleus Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-maven-plugin</artifactId>
-    <version>5.0.0-release-SNAPSHOT</version>
+    <version>5.0.0-release</version>
     <packaging>maven-plugin</packaging>
 
     <name>DataNucleus Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-maven-plugin</artifactId>
-    <version>5.0.0-release</version>
+    <version>5.0.1-release-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>DataNucleus Maven Plugin</name>

--- a/src/main/java/org/datanucleus/maven/AbstractDataNucleusMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractDataNucleusMojo.java
@@ -61,11 +61,7 @@ public abstract class AbstractDataNucleusMojo extends AbstractMojo
      */
     protected boolean ignoreMetaDataForMissingClasses;
 
-    /**
-     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
-     * @required
-     */
-    private List classpathElements;
+    abstract List getClasspathElements();
 
     /**
      * @parameter expression="${plugin.artifacts}"
@@ -223,7 +219,8 @@ public abstract class AbstractDataNucleusMojo extends AbstractMojo
     {
         List ret = new ArrayList();
         ret.add(this.metadataDirectory.getAbsolutePath());
-        Iterator it = classpathElements.iterator();
+        Iterator it = getClasspathElements().iterator();
+
         while (it.hasNext())
         {
             String pathelem = (String) it.next();

--- a/src/main/java/org/datanucleus/maven/AbstractEnhancerCheckMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractEnhancerCheckMojo.java
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contributors:
-2007 Andy Jefferson - migrated to JPOX, formatted, etc
+2007 Andy Jefferson - split out base class for all enhancer modes.
+2011 Marco หงุ่ยตระกูล-Schulze - changed "@requiresDependencyResolution" to "compile"
     ...
 **********************************************************************/
 package org.datanucleus.maven;
@@ -22,42 +23,24 @@ import java.util.List;
 
 import org.codehaus.plexus.util.cli.Commandline;
 
-/**
- * Provides a detailed information about the database schema.
- * @goal schema-info
- * @requiresDependencyResolution
- */
-public class SchemaToolInfoMojo extends AbstractSchemaToolMojo
+public abstract class AbstractEnhancerCheckMojo extends AbstractEnhancerMojo
 {
-    private static final String OPERATION_MODE_SCHEMA_INFO = "-schemainfo";
-
     /**
-     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
-     * @required
-     */
-    private List classpathElements;
-
-    @Override
-    List getClasspathElements() {
-        return classpathElements;
-    }
-
-
-
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)
+     * Method to add on any additional command line arguments for this mode of invoking the
+     * DataNucleus Enhancer.
+     * @param cl The current CommandLine
+     * @param args Args that will be updated with anything appended here
      */
     protected void prepareModeSpecificCommandLineArguments(Commandline cl, List args)
     {
+        // Use "checkonly" mode
         if (fork)
         {
-            cl.createArg().setValue(OPERATION_MODE_SCHEMA_INFO);
+            cl.createArg().setValue("-checkonly");
         }
         else
         {
-            args.add(OPERATION_MODE_SCHEMA_INFO);
+            args.add("-checkonly");
         }
     }
 }

--- a/src/main/java/org/datanucleus/maven/AbstractEnhancerEnhanceMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractEnhancerEnhanceMojo.java
@@ -1,5 +1,5 @@
 /**********************************************************************
-Copyright (c) 2005 Rahul Thakur and others. All rights reserved.
+Copyright (c) 2007 Andy Jefferson and others. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -13,9 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contributors:
-2007 Andy Jefferson - split out base class for all enhancer modes.
-2011 Marco หงุ่ยตระกูล-Schulze - changed "@requiresDependencyResolution" to "compile"
-    ...
+ 2016 Dan Haywood - https://github.com/datanucleus/datanucleus-maven-plugin/issues/5
 **********************************************************************/
 package org.datanucleus.maven;
 
@@ -23,15 +21,14 @@ import java.util.List;
 
 import org.codehaus.plexus.util.cli.Commandline;
 
-/**
- * Goal to check the enhancement status of the provided classes.
- * @goal enhance-check
- * @phase process-classes
- * @requiresDependencyResolution compile
- * @description Checks the enhancement of the input classes.
- */
-public class EnhancerCheckMojo extends AbstractEnhancerMojo
+public abstract class AbstractEnhancerEnhanceMojo extends AbstractEnhancerMojo
 {
+    /**
+     * @parameter expression="${targetDirectory}" default-value=""
+     */
+    private String targetDirectory;
+
+
     /**
      * Method to add on any additional command line arguments for this mode of invoking the
      * DataNucleus Enhancer.
@@ -40,14 +37,20 @@ public class EnhancerCheckMojo extends AbstractEnhancerMojo
      */
     protected void prepareModeSpecificCommandLineArguments(Commandline cl, List args)
     {
-        // Use "checkonly" mode
-        if (fork)
+        if (targetDirectory != null && targetDirectory.trim().length() > 0)
         {
-            cl.createArg().setValue("-checkonly");
-        }
-        else
-        {
-            args.add("-checkonly");
+            // Output the enhanced classes to a different location
+            if (fork)
+            {
+                cl.createArg().setValue("-d");
+                cl.createArg().setValue(targetDirectory);
+            }
+            else
+            {
+                args.add("-d");
+                args.add(targetDirectory);
+            }
         }
     }
+
 }

--- a/src/main/java/org/datanucleus/maven/AbstractSchemaToolMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractSchemaToolMojo.java
@@ -101,7 +101,13 @@ public abstract class AbstractSchemaToolMojo extends AbstractDataNucleusMojo
     private Properties toolProperties;
 
     /**
-     * Schema name (to be used with "createSchema"/"deleteSchema" modes).
+     * Catalog name (to be used with "createDatabase"/"deleteDatabase" modes).
+     * @parameter expression="${catalogName}" default-value=""
+     */
+    protected String catalogName;
+
+    /**
+     * Schema name (to be used with "createDatabase"/"deleteDatabase" modes).
      * @parameter expression="${schemaName}" default-value=""
      */
     protected String schemaName;

--- a/src/main/java/org/datanucleus/maven/EnhancerEnhanceCheckMojo.java
+++ b/src/main/java/org/datanucleus/maven/EnhancerEnhanceCheckMojo.java
@@ -13,23 +13,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contributors:
-2007 Andy Jefferson - migrated to JPOX, formatted, etc
+2007 Andy Jefferson - split out base class for all enhancer modes.
+2011 Marco หงุ่ยตระกูล-Schulze - changed "@requiresDependencyResolution" to "compile"
+2016 Dan Haywood - https://github.com/datanucleus/datanucleus-maven-plugin/issues/5
     ...
 **********************************************************************/
 package org.datanucleus.maven;
 
 import java.util.List;
 
-import org.codehaus.plexus.util.cli.Commandline;
-
 /**
- * Provides a detailed information about the database schema.
- * @goal schema-info
- * @requiresDependencyResolution
+ * Goal to check the enhancement status of the provided classes.
+ *
+ * @goal enhance-check
+ * @phase process-classes
+ * @requiresDependencyResolution compile
+ * @description Checks the enhancement of the input classes.
  */
-public class SchemaToolInfoMojo extends AbstractSchemaToolMojo
+public class EnhancerEnhanceCheckMojo extends AbstractEnhancerCheckMojo
 {
-    private static final String OPERATION_MODE_SCHEMA_INFO = "-schemainfo";
 
     /**
      * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
@@ -42,22 +44,4 @@ public class SchemaToolInfoMojo extends AbstractSchemaToolMojo
         return classpathElements;
     }
 
-
-
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)
-     */
-    protected void prepareModeSpecificCommandLineArguments(Commandline cl, List args)
-    {
-        if (fork)
-        {
-            cl.createArg().setValue(OPERATION_MODE_SCHEMA_INFO);
-        }
-        else
-        {
-            args.add(OPERATION_MODE_SCHEMA_INFO);
-        }
-    }
 }

--- a/src/main/java/org/datanucleus/maven/EnhancerEnhanceMojo.java
+++ b/src/main/java/org/datanucleus/maven/EnhancerEnhanceMojo.java
@@ -21,8 +21,6 @@ package org.datanucleus.maven;
 
 import java.util.List;
 
-import org.codehaus.plexus.util.cli.Commandline;
-
 /**
  * Goal to enhance the provided classes as per the input file definition.
  *
@@ -31,33 +29,18 @@ import org.codehaus.plexus.util.cli.Commandline;
  * @requiresDependencyResolution compile
  * @description Enhances the input classes.
  */
-public class EnhancerMojo extends AbstractEnhancerMojo {
-    /**
-     * @parameter expression="${targetDirectory}" default-value=""
-     */
-    private String targetDirectory;
+public class EnhancerEnhanceMojo extends AbstractEnhancerEnhanceMojo {
 
     /**
-     * Method to add on any additional command line arguments for this mode of invoking the
-     * DataNucleus Enhancer.
-     * @param cl The current CommandLine
-     * @param args Args that will be updated with anything appended here
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
      */
-    protected void prepareModeSpecificCommandLineArguments(Commandline cl, List args)
-    {
-        if (targetDirectory != null && targetDirectory.trim().length() > 0)
-        {
-            // Output the enhanced classes to a different location
-            if (fork)
-            {
-                cl.createArg().setValue("-d");
-                cl.createArg().setValue(targetDirectory);
-            }
-            else
-            {
-                args.add("-d");
-                args.add(targetDirectory);
-            }
-        }
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
     }
+
+
 }

--- a/src/main/java/org/datanucleus/maven/EnhancerTestEnhanceCheckMojo.java
+++ b/src/main/java/org/datanucleus/maven/EnhancerTestEnhanceCheckMojo.java
@@ -13,26 +13,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contributors:
-2007 Andy Jefferson - migrated to JPOX, formatted, etc
+ 2016 Dan Haywood - https://github.com/datanucleus/datanucleus-maven-plugin/issues/5
     ...
 **********************************************************************/
 package org.datanucleus.maven;
 
 import java.util.List;
 
-import org.codehaus.plexus.util.cli.Commandline;
-
 /**
- * Provides a detailed information about the database schema.
- * @goal schema-info
- * @requiresDependencyResolution
+ * Goal to check the enhancement status of the provided classes.
+ *
+ * @goal test-enhance-check
+ * @phase process-test-classes
+ * @requiresDependencyResolution test
+ * @description Checks the enhancement of the input classes.
  */
-public class SchemaToolInfoMojo extends AbstractSchemaToolMojo
+public class EnhancerTestEnhanceCheckMojo extends AbstractEnhancerCheckMojo
 {
-    private static final String OPERATION_MODE_SCHEMA_INFO = "-schemainfo";
 
     /**
-     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @parameter expression="${classpath}" default-value="${project.testClasspathElements}"
      * @required
      */
     private List classpathElements;
@@ -42,22 +42,4 @@ public class SchemaToolInfoMojo extends AbstractSchemaToolMojo
         return classpathElements;
     }
 
-
-
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)
-     */
-    protected void prepareModeSpecificCommandLineArguments(Commandline cl, List args)
-    {
-        if (fork)
-        {
-            cl.createArg().setValue(OPERATION_MODE_SCHEMA_INFO);
-        }
-        else
-        {
-            args.add(OPERATION_MODE_SCHEMA_INFO);
-        }
-    }
 }

--- a/src/main/java/org/datanucleus/maven/EnhancerTestEnhanceMojo.java
+++ b/src/main/java/org/datanucleus/maven/EnhancerTestEnhanceMojo.java
@@ -1,0 +1,43 @@
+/**********************************************************************
+ Copyright (c) 2005 Rahul Thakur and others. All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Contributors:
+ 2016 Dan Haywood - https://github.com/datanucleus/datanucleus-maven-plugin/issues/5
+ ...
+**********************************************************************/
+package org.datanucleus.maven;
+
+import java.util.List;
+
+/**
+ * Goal to enhance the provided classes as per the input file definition.
+ *
+ * @goal test-enhance
+ * @phase process-test-classes
+ * @requiresDependencyResolution test
+ * @description Enhances the input classes.
+ */
+public class EnhancerTestEnhanceMojo extends AbstractEnhancerEnhanceMojo {
+
+    /**
+     * @parameter expression="${classpath}" default-value="${project.testClasspathElements}"
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+}

--- a/src/main/java/org/datanucleus/maven/SchemaToolCreateDatabaseMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolCreateDatabaseMojo.java
@@ -32,6 +32,20 @@ public class SchemaToolCreateDatabaseMojo extends AbstractSchemaToolMojo
     private static final String OPERATION_MODE_CREATE = "-createDatabase";
 
     /**
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+
+
+
+    /**
      * {@inheritDoc}
      * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)
      */

--- a/src/main/java/org/datanucleus/maven/SchemaToolCreateDatabaseMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolCreateDatabaseMojo.java
@@ -22,14 +22,14 @@ import java.util.List;
 import org.codehaus.plexus.util.cli.Commandline;
 
 /**
- * Deletes the schema specified by the "schemaName" parameter.
- * @goal schema-deleteschema
+ * Generates the database specified by the catalogName/schemaName parameters.
+ * @goal schema-createdatabase
  * @requiresDependencyResolution runtime
- * @description Deletes the datastore schema for the specified schemaName.
+ * @description Creates the database for the specified catalogName/schemaName.
  */
-public class SchemaToolDeleteSchemaMojo extends AbstractSchemaToolMojo
+public class SchemaToolCreateDatabaseMojo extends AbstractSchemaToolMojo
 {
-    private static final String OPERATION_MODE_DELETE = "-deleteSchema";
+    private static final String OPERATION_MODE_CREATE = "-createDatabase";
 
     /**
      * {@inheritDoc}
@@ -39,13 +39,31 @@ public class SchemaToolDeleteSchemaMojo extends AbstractSchemaToolMojo
     {
         if (fork)
         {
-            cl.createArg().setValue(OPERATION_MODE_DELETE);
-            cl.createArg().setValue(schemaName);
+            cl.createArg().setValue(OPERATION_MODE_CREATE);
+
+            if (catalogName != null && !catalogName.isEmpty())
+            {
+                cl.createArg().setLine("-catalog " + catalogName);
+            }
+            if (schemaName != null && !schemaName.isEmpty())
+            {
+                cl.createArg().setLine("-schema " + schemaName);
+            }
         }
         else
         {
-            args.add(OPERATION_MODE_DELETE);
-            args.add(schemaName);
+            args.add(OPERATION_MODE_CREATE);
+
+            if (catalogName != null && !catalogName.isEmpty())
+            {
+                args.add("-catalog");
+                args.add(catalogName);
+            }
+            if (schemaName != null && !schemaName.isEmpty())
+            {
+                args.add("-schema");
+                args.add(schemaName);
+            }
         }
     }
 }

--- a/src/main/java/org/datanucleus/maven/SchemaToolCreateMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolCreateMojo.java
@@ -33,6 +33,18 @@ public class SchemaToolCreateMojo extends AbstractSchemaToolMojo
     private static final String OPERATION_MODE_CREATE = "-create";
 
     /**
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+
+    /**
      * {@inheritDoc}
      * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)
      */

--- a/src/main/java/org/datanucleus/maven/SchemaToolDatabaseInfoMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolDatabaseInfoMojo.java
@@ -32,6 +32,20 @@ public class SchemaToolDatabaseInfoMojo extends AbstractSchemaToolMojo
     private static final String OPERATION_MODE_DB_INFO = "-dbinfo";
 
     /**
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+
+
+
+    /**
      * {@inheritDoc}
      * 
      * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)

--- a/src/main/java/org/datanucleus/maven/SchemaToolDeleteCreateMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolDeleteCreateMojo.java
@@ -32,6 +32,20 @@ public class SchemaToolDeleteCreateMojo extends AbstractSchemaToolMojo
     private static final String OPERATION_MODE_DELETECREATE = "-deletecreate";
 
     /**
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+
+
+
+    /**
      * {@inheritDoc}
      * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)
      */

--- a/src/main/java/org/datanucleus/maven/SchemaToolDeleteDatabaseMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolDeleteDatabaseMojo.java
@@ -32,6 +32,19 @@ public class SchemaToolDeleteDatabaseMojo extends AbstractSchemaToolMojo
     private static final String OPERATION_MODE_DELETE = "-deleteDatabase";
 
     /**
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+
+
+    /**
      * {@inheritDoc}
      * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)
      */

--- a/src/main/java/org/datanucleus/maven/SchemaToolDeleteDatabaseMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolDeleteDatabaseMojo.java
@@ -22,14 +22,14 @@ import java.util.List;
 import org.codehaus.plexus.util.cli.Commandline;
 
 /**
- * Generates the schema specified by the "schemaName" parameter.
- * @goal schema-createschema
+ * Deletes the database specified by the catalogName/schemaName parameters.
+ * @goal schema-deletedatabase
  * @requiresDependencyResolution runtime
- * @description Creates the datastore schema for the specified schemaName.
+ * @description Deletes the database for the specified catalogName/schemaName.
  */
-public class SchemaToolCreateSchemaMojo extends AbstractSchemaToolMojo
+public class SchemaToolDeleteDatabaseMojo extends AbstractSchemaToolMojo
 {
-    private static final String OPERATION_MODE_CREATE = "-createSchema";
+    private static final String OPERATION_MODE_DELETE = "-deleteDatabase";
 
     /**
      * {@inheritDoc}
@@ -39,13 +39,31 @@ public class SchemaToolCreateSchemaMojo extends AbstractSchemaToolMojo
     {
         if (fork)
         {
-            cl.createArg().setValue(OPERATION_MODE_CREATE);
-            cl.createArg().setValue(schemaName);
+            cl.createArg().setValue(OPERATION_MODE_DELETE);
+
+            if (catalogName != null && !catalogName.isEmpty())
+            {
+                cl.createArg().setLine("-catalog " + catalogName);
+            }
+            if (schemaName != null && !schemaName.isEmpty())
+            {
+                cl.createArg().setLine("-schema " + schemaName);
+            }
         }
         else
         {
-            args.add(OPERATION_MODE_CREATE);
-            args.add(schemaName);
+            args.add(OPERATION_MODE_DELETE);
+
+            if (catalogName != null && !catalogName.isEmpty())
+            {
+                args.add("-catalog");
+                args.add(catalogName);
+            }
+            if (schemaName != null && !schemaName.isEmpty())
+            {
+                args.add("-schema");
+                args.add(schemaName);
+            }
         }
     }
 }

--- a/src/main/java/org/datanucleus/maven/SchemaToolDeleteMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolDeleteMojo.java
@@ -32,6 +32,19 @@ public class SchemaToolDeleteMojo extends AbstractSchemaToolMojo
     private static final String OPERATION_MODE_DELETE = "-delete";
 
     /**
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+
+
+    /**
      * {@inheritDoc}
      * 
      * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)

--- a/src/main/java/org/datanucleus/maven/SchemaToolValidateMojo.java
+++ b/src/main/java/org/datanucleus/maven/SchemaToolValidateMojo.java
@@ -32,6 +32,20 @@ public class SchemaToolValidateMojo extends AbstractSchemaToolMojo
     private static final String OPERATION_MODE_VALIDATE = "-validate";
 
     /**
+     * @parameter expression="${classpath}" default-value="${project.compileClasspathElements}"
+     * @required
+     */
+    private List classpathElements;
+
+    @Override
+    List getClasspathElements() {
+        return classpathElements;
+    }
+
+
+
+
+    /**
      * {@inheritDoc}
      * 
      * @see org.datanucleus.maven.AbstractSchemaToolMojo#prepareModeSpecificCommandLineArguments(org.codehaus.plexus.util.cli.Commandline, java.util.List)


### PR DESCRIPTION
Basically:

* AbstractDataNucleusMojo no longer defines 'classpathElements' field, instead has an abstract getClasspathElements() method.
* The subclasses provide the concrete implementations of this method, with defaults based on whether they are for goals in the 'compile' (src/main/java) or 'test' (src/test/java) scope
* The original 'EnhancerMojo' is split into two:
    * 'AbstractEnhancerEnhanceMojo' has all the code except the implementation of getClasspathElements()
    * 'EnhancerEnhanceMojo' is the the concrete subclass that implements getClasspathElements()
* a new 'EnhancerTestEnhanceMojo' provides the new 'test-enhance' goal; it is almost identical to 'EnhancerEnhanceMojo', but with different annotations
* Similarly, the original 'EnhancerCheckMojo' is split into two:
    * 'AbstractEnhancerTestMojo' has most of the code
    * 'EnhancerEnhanceCheckMojo' is the subclass
* a new 'EnhancerTestEnhanceCheckMojo' provides the new 'test-enhance-check' goal.