### PR TITLE
Added Java 9/10 compatibility

### DIFF
--- a/src/main/java/org/datanucleus/maven/AbstractDataNucleusMojo.java
+++ b/src/main/java/org/datanucleus/maven/AbstractDataNucleusMojo.java
@@ -307,7 +307,17 @@ public abstract class AbstractDataNucleusMojo extends AbstractMojo
                 }
             }
 
-            URLClassLoader loader = new URLClassLoader(urls, null);
+            ClassLoader parent = null;
+            try
+            {
+                parent = ClassLoader.getPlatformClassLoader();
+                getLog().debug("Java 9 or higher detected. Using modern classloader strategy.");
+            }
+            catch (NoSuchMethodError e)
+            {
+                getLog().debug("Java 8 or older detected. Using legacy classloader strategy.");
+            }
+            URLClassLoader loader = new URLClassLoader(urls, parent);
             Class c = loader.loadClass(className);
             Method m = c.getMethod("main", new Class[] { String[].class });
             ClassLoader tl = Thread.currentThread().getContextClassLoader();


### PR DESCRIPTION
Enhancing on Java 10 (haven't tried 9) results in several ClassNotFoundExceptions (and similar) attempting to access classes in the java.sql package.

Java 9 introduces a new method (ClassLoader.getPlatformClassLoader()) that must be passed to the URLClassLoader in order to resolve many of these classes. This method does not exist in Java 8 and lower. Therefore, this PR performs a check and should work regardless of Java version used.

It will need to be compiled with Java 9 or higher, but is compatible with previous Java versions.

I've tested this with JDO enhancing on both Java 8 and Java 10.